### PR TITLE
Add Qt JavaScript (QJSEngine) script example

### DIFF
--- a/examples/qt-jsengine-example/CMakeLists.txt
+++ b/examples/qt-jsengine-example/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.16)
+project(qt_jsengine_example LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_AUTOMOC ON)
+
+# 同时支持 Qt5 和 Qt6
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Qml)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Qml)
+
+add_executable(qt_jsengine_example
+    main.cpp
+)
+
+target_link_libraries(qt_jsengine_example
+    PRIVATE
+        Qt${QT_VERSION_MAJOR}::Core
+        Qt${QT_VERSION_MAJOR}::Qml
+)
+
+# 把 scripts/ 拷到可执行文件旁边，运行时 main.cpp 会从那里加载
+add_custom_command(TARGET qt_jsengine_example POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_CURRENT_SOURCE_DIR}/scripts
+        $<TARGET_FILE_DIR:qt_jsengine_example>/scripts
+)

--- a/examples/qt-jsengine-example/README.md
+++ b/examples/qt-jsengine-example/README.md
@@ -1,0 +1,134 @@
+# Qt JavaScript 模块（QJSEngine）脚本示例
+
+本示例展示如何在 C++ 程序里嵌入 [Qt JavaScript 引擎](https://doc.qt.io/qt-6/qjsengine.html)
+（`QJSEngine`，位于 `Qt Qml` 模块），把 JavaScript 当作脚本语言用，并实现 C++ 与 JS 双向调用。
+
+> 适用 Qt 5.12+ 与 Qt 6（在 Qt 6 中 `QJSEngine` 仍由 `Qt6::Qml` 提供）。
+
+## 功能演示
+
+`main.cpp` 中按顺序演示了 6 个常见用法：
+
+| 编号 | 主题                                    | 关键 API                                              |
+| ---- | --------------------------------------- | ----------------------------------------------------- |
+| 1    | 直接执行字符串脚本                      | `QJSEngine::evaluate(QString)`                        |
+| 2    | 从 `.js` 文件加载并调用其中函数         | `QJSValue::call`                                      |
+| 3    | 把 C++ `QObject` 暴露给 JS（属性 / 槽） | `QJSEngine::newQObject` + `globalObject().setProperty`|
+| 4    | 把 C++ 信号连到 JS 回调                 | JS 端 `signal.connect(handler)`                       |
+| 5    | 在 JS 里 `new` C++ 类型                 | `QJSEngine::newQMetaObject`                           |
+| 6    | 复杂业务脚本（`scripts/app_logic.js`）  | 综合使用以上能力                                      |
+
+并且在 `checkError()` 里集中处理 JS 异常（含 fileName / lineNumber / stack）。
+
+## 目录结构
+
+```
+qt-jsengine-example/
+├── CMakeLists.txt              # CMake 构建（推荐）
+├── qt_jsengine_example.pro     # qmake 构建（可选）
+├── main.cpp                    # 宿主程序
+├── scripts/
+│   ├── hello.js                # 最简单脚本
+│   └── app_logic.js            # 使用注入 C++ 对象的脚本
+└── README.md
+```
+
+## 构建与运行
+
+### 用 CMake
+
+```bash
+cd examples/qt-jsengine-example
+cmake -S . -B build -DCMAKE_PREFIX_PATH=<你的 Qt 安装前缀>
+cmake --build build
+./build/qt_jsengine_example
+```
+
+`CMAKE_PREFIX_PATH` 例如：
+- Linux: `/opt/Qt/6.7.0/gcc_64`
+- macOS: `~/Qt/6.7.0/macos`
+- Windows (MSVC): `C:/Qt/6.7.0/msvc2019_64`
+
+### 用 qmake
+
+```bash
+cd examples/qt-jsengine-example
+qmake
+make            # Windows 上根据工具链改成 nmake / mingw32-make
+./qt_jsengine_example
+```
+
+## 期望输出（节选）
+
+```
+=== Demo 1: evaluate(string) ===
+fib(12) = 144
+
+=== Demo 2: evaluate(file) === ".../scripts/hello.js"
+hello.js loaded, PI = 3.1416
+greet("Qt") => Hello, Qt! (from hello.js)
+
+=== Demo 3: expose QObject to JS ===
+[JS->C++] Hello from JavaScript, app name = Qt JS Example
+result = QMap(("counter", 42)("echoed", QMap(...))("sum", 7))
+counter (C++ side) = 42
+
+=== Demo 4: C++ signal -> JS callback ===
+[JS->C++] tick received in JS, n = 1
+[JS->C++] tick received in JS, n = 2
+[JS->C++] tick received in JS, n = 3
+
+=== Demo 5: JS-newable C++ type (Vector2) ===
+result = QMap(("len", 5)("str", "Vector2(3, 4)"))
+
+=== Demo 6: complex script using app ===
+[JS->C++] app_logic.js running, appName = Qt JS Example
+[JS->C++] sum(1..10) via C++ add() = 55
+...
+```
+
+## 关键点说明
+
+### 1. 暴露 QObject
+
+只有 `Q_PROPERTY` 标记的属性、`public slots:` 里的函数、以及 `Q_INVOKABLE` 标记的方法
+才会被 `QJSEngine` 暴露给 JS。信号默认带有 `connect` / `disconnect` 方法。
+
+### 2. 对象所有权
+
+`engine.newQObject(obj)` 默认会把对象的所有权交给 JS 引擎（GC 时会被删除）。如果 C++ 端
+还要继续使用，需要：
+
+```cpp
+QQmlEngine::setObjectOwnership(api, QQmlEngine::CppOwnership);
+```
+
+### 3. 异常处理
+
+`QJSValue::isError()` 为真时即代表脚本抛了异常，可以读取 `message / fileName /
+lineNumber / stack` 等属性。建议每次 `evaluate` / `call` 后都用一个统一的
+`checkError()` 包一下。
+
+### 4. ConsoleExtension
+
+```cpp
+engine.installExtensions(QJSEngine::ConsoleExtension);
+```
+
+之后 JS 里就能用 `console.log / warn / error` 输出到 Qt 日志系统。
+
+### 5. 让 JS 能 `new` C++ 类型
+
+```cpp
+QJSValue ctor = engine.newQMetaObject(&Vector2::staticMetaObject);
+engine.globalObject().setProperty("Vector2", ctor);
+```
+
+要求构造函数是 `Q_INVOKABLE`，所有要被 JS 看到的方法 / 属性同样要 `Q_INVOKABLE`
+或 `Q_PROPERTY`。
+
+## 参考
+
+- [QJSEngine](https://doc.qt.io/qt-6/qjsengine.html)
+- [QJSValue](https://doc.qt.io/qt-6/qjsvalue.html)
+- [Qt QML JavaScript Host Environment](https://doc.qt.io/qt-6/qtqml-javascript-hostenvironment.html)

--- a/examples/qt-jsengine-example/main.cpp
+++ b/examples/qt-jsengine-example/main.cpp
@@ -1,0 +1,259 @@
+// Qt JavaScript 模块（QJSEngine）综合示例
+//
+// 本示例演示：
+//   1) 用 QJSEngine 加载并执行 JS 文件
+//   2) 把 C++ 的 QObject 暴露成 JS 全局对象
+//   3) 在 JS 里调用 C++ 的槽函数和属性
+//   4) 在 C++ 里调用 JS 函数并读取返回值
+//   5) 异常 / 错误处理
+//   6) 通过 QJSEngine 注册 C++ 可被 JS new 出来的类型
+//
+// 编译需要：Qt 5.12+ 或 Qt 6（Qml 模块提供 QJSEngine）
+
+#include <QtCore/QCoreApplication>
+#include <QtCore/QDebug>
+#include <QtCore/QFile>
+#include <QtCore/QObject>
+#include <QtCore/QTextStream>
+#include <QtCore/QTimer>
+
+#include <QtQml/QJSEngine>
+#include <QtQml/QJSValue>
+#include <QtQml/QJSValueIterator>
+#include <QtQml/QQmlEngine>
+
+// ---------------------------------------------------------------------------
+// 一个普通 QObject：用来从 JS 端访问其属性 / 槽 / 信号
+// ---------------------------------------------------------------------------
+class AppApi : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString appName READ appName CONSTANT)
+    Q_PROPERTY(int counter READ counter WRITE setCounter NOTIFY counterChanged)
+
+public:
+    explicit AppApi(QObject *parent = nullptr) : QObject(parent) {}
+
+    QString appName() const { return QStringLiteral("Qt JS Example"); }
+
+    int counter() const { return m_counter; }
+    void setCounter(int v)
+    {
+        if (m_counter == v) return;
+        m_counter = v;
+        emit counterChanged(v);
+    }
+
+public slots:
+    // JS 里可以直接调用：app.log("hello")
+    void log(const QString &msg) { qInfo().noquote() << "[JS->C++]" << msg; }
+
+    // 返回值能被 JS 接收
+    int add(int a, int b) const { return a + b; }
+
+    // 把任意 JS 对象 / 数组 反序列化到 C++（用 QVariant）
+    QVariant echo(const QVariant &v) const { return v; }
+
+signals:
+    void counterChanged(int value);
+    void tick(int n);
+};
+
+// ---------------------------------------------------------------------------
+// 一个可被 JS 用 new 创建的类型：演示 QJSEngine::newQObject + 构造函数
+// ---------------------------------------------------------------------------
+class Vector2 : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(double x MEMBER x)
+    Q_PROPERTY(double y MEMBER y)
+
+public:
+    Q_INVOKABLE Vector2(double x_ = 0.0, double y_ = 0.0, QObject *parent = nullptr)
+        : QObject(parent), x(x_), y(y_) {}
+
+    Q_INVOKABLE double length() const { return std::sqrt(x * x + y * y); }
+    Q_INVOKABLE QString toString() const
+    {
+        return QStringLiteral("Vector2(%1, %2)").arg(x).arg(y);
+    }
+
+    double x = 0.0;
+    double y = 0.0;
+};
+
+// ---------------------------------------------------------------------------
+// 工具函数：把脚本文件读入字符串
+// ---------------------------------------------------------------------------
+static QString readScript(const QString &path)
+{
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qWarning() << "Cannot open script:" << path << f.errorString();
+        return {};
+    }
+    return QTextStream(&f).readAll();
+}
+
+// ---------------------------------------------------------------------------
+// 通用错误处理：检查 JS 求值结果是否为异常
+// ---------------------------------------------------------------------------
+static bool checkError(const QJSValue &result, const QString &where)
+{
+    if (!result.isError()) return false;
+    qCritical().noquote()
+        << "JS Error in" << where
+        << "\n  message :" << result.toString()
+        << "\n  file    :" << result.property("fileName").toString()
+        << "\n  line    :" << result.property("lineNumber").toInt()
+        << "\n  stack   :\n" << result.property("stack").toString();
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// 演示 1：直接执行字符串脚本
+// ---------------------------------------------------------------------------
+static void demoEvaluateString(QJSEngine &engine)
+{
+    qInfo() << "\n=== Demo 1: evaluate(string) ===";
+    const QJSValue r = engine.evaluate(
+        "function fib(n){ return n<2 ? n : fib(n-1)+fib(n-2); } fib(12);");
+    if (!checkError(r, "demoEvaluateString"))
+        qInfo() << "fib(12) =" << r.toInt();
+}
+
+// ---------------------------------------------------------------------------
+// 演示 2：从文件加载脚本，并调用其中定义的函数
+// ---------------------------------------------------------------------------
+static void demoEvaluateFile(QJSEngine &engine, const QString &path)
+{
+    qInfo() << "\n=== Demo 2: evaluate(file) ===" << path;
+    const QString src = readScript(path);
+    if (src.isEmpty()) return;
+
+    const QJSValue r = engine.evaluate(src, path);
+    if (checkError(r, path)) return;
+
+    // 调用脚本里定义的 greet(name)
+    QJSValue greet = engine.globalObject().property("greet");
+    if (greet.isCallable()) {
+        QJSValue ret = greet.call({ QJSValue("Qt") });
+        if (!checkError(ret, "greet()"))
+            qInfo().noquote() << "greet(\"Qt\") =>" << ret.toString();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 演示 3：把 C++ 对象注入到 JS 全局
+// ---------------------------------------------------------------------------
+static void demoInjectQObject(QJSEngine &engine, AppApi *api)
+{
+    qInfo() << "\n=== Demo 3: expose QObject to JS ===";
+    QJSValue jsApi = engine.newQObject(api);
+    QQmlEngine::setObjectOwnership(api, QQmlEngine::CppOwnership);
+    engine.globalObject().setProperty("app", jsApi);
+
+    const QJSValue r = engine.evaluate(R"JS(
+        app.log("Hello from JavaScript, app name = " + app.appName);
+        app.counter = 41;
+        app.counter = app.counter + 1;          // -> 42
+        var sum = app.add(3, 4);                // C++ 槽
+        var echoed = app.echo({a:1, b:[2,3]});  // QVariant 互转
+        ({ counter: app.counter, sum: sum, echoed: echoed });
+    )JS");
+    if (checkError(r, "demoInjectQObject")) return;
+
+    qInfo().noquote() << "result =" << r.toVariant();
+    qInfo() << "counter (C++ side) =" << api->counter();
+}
+
+// ---------------------------------------------------------------------------
+// 演示 4：在 C++ 中调用 JS 函数，并把 C++ 信号转到 JS 回调
+// ---------------------------------------------------------------------------
+static void demoSignalToJsCallback(QJSEngine &engine, AppApi *api)
+{
+    qInfo() << "\n=== Demo 4: C++ signal -> JS callback ===";
+
+    // 在 JS 里定义一个回调
+    QJSValue setup = engine.evaluate(R"JS(
+        (function() {
+            return function onTick(n) {
+                app.log("tick received in JS, n = " + n);
+            };
+        })()
+    )JS");
+    if (checkError(setup, "demoSignalToJsCallback/setup")) return;
+
+    // 把信号连到 JS 函数
+    // QJSEngine 支持把 callable 直接 connect 到 QObject 的信号：
+    QJSValue connectFn = engine.globalObject()
+                            .property("app")
+                            .property("tick")
+                            .property("connect");
+    if (connectFn.isCallable()) {
+        QJSValue conRet = connectFn.callWithInstance(
+            engine.globalObject().property("app").property("tick"),
+            { setup });
+        checkError(conRet, "tick.connect");
+    }
+
+    // 触发几次信号
+    for (int i = 1; i <= 3; ++i) emit api->tick(i);
+}
+
+// ---------------------------------------------------------------------------
+// 演示 5：注册可被 JS new 的 C++ 类型
+// ---------------------------------------------------------------------------
+static void demoNewableType(QJSEngine &engine)
+{
+    qInfo() << "\n=== Demo 5: JS-newable C++ type (Vector2) ===";
+
+    // 注册 Vector2 元类型，让 JS 能 new Vector2(x,y)
+    QJSValue ctor = engine.newQMetaObject(&Vector2::staticMetaObject);
+    engine.globalObject().setProperty("Vector2", ctor);
+
+    const QJSValue r = engine.evaluate(R"JS(
+        var v = new Vector2(3, 4);
+        ({ str: v.toString(), len: v.length() });
+    )JS");
+    if (!checkError(r, "demoNewableType"))
+        qInfo().noquote() << "result =" << r.toVariant();
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    QJSEngine engine;
+    engine.installExtensions(QJSEngine::ConsoleExtension
+                             | QJSEngine::GarbageCollectionExtension);
+
+    AppApi api;
+
+    demoEvaluateString(engine);
+
+    // 默认从可执行文件目录的 ./scripts 加载
+    const QString scriptsDir = QCoreApplication::applicationDirPath() + "/scripts";
+    demoEvaluateFile(engine, scriptsDir + "/hello.js");
+
+    demoInjectQObject(engine, &api);
+    demoSignalToJsCallback(engine, &api);
+    demoNewableType(engine);
+
+    // 再加载一段使用 app 对象的复杂脚本
+    qInfo() << "\n=== Demo 6: complex script using app ===";
+    const QString src = readScript(scriptsDir + "/app_logic.js");
+    if (!src.isEmpty()) {
+        QJSValue r = engine.evaluate(src, "app_logic.js");
+        checkError(r, "app_logic.js");
+    }
+
+    // 让事件循环跑一下后退出（用于演示信号 / 定时器）
+    QTimer::singleShot(0, &app, &QCoreApplication::quit);
+    return app.exec();
+}
+
+#include "main.moc"

--- a/examples/qt-jsengine-example/qt_jsengine_example.pro
+++ b/examples/qt-jsengine-example/qt_jsengine_example.pro
@@ -1,0 +1,21 @@
+QT       += core qml
+QT       -= gui
+
+CONFIG   += c++17 console
+CONFIG   -= app_bundle
+
+TARGET   = qt_jsengine_example
+TEMPLATE = app
+
+SOURCES += main.cpp
+
+# 把脚本拷到构建输出目录
+scripts.path = $$OUT_PWD/scripts
+scripts.files = $$PWD/scripts/*
+INSTALLS += scripts
+
+# 也在每次构建后拷贝一次（方便 IDE 直接 Run）
+copy_scripts.commands = $(MKDIR) $$shell_path($$OUT_PWD/scripts) && \
+                        $(COPY_DIR) $$shell_path($$PWD/scripts) $$shell_path($$OUT_PWD)
+QMAKE_EXTRA_TARGETS += copy_scripts
+POST_TARGETDEPS     += copy_scripts

--- a/examples/qt-jsengine-example/scripts/app_logic.js
+++ b/examples/qt-jsengine-example/scripts/app_logic.js
@@ -1,0 +1,41 @@
+// app_logic.js —— 演示在 JS 中使用注入的 C++ 对象 `app`
+// 期望全局存在：
+//   app   : C++ 端的 AppApi（QObject）
+//   Vector2 : C++ 端注册的可 new 类型
+
+(function () {
+    "use strict";
+
+    app.log("app_logic.js running, appName = " + app.appName);
+
+    // 1) 用 C++ 的 add() 做点计算
+    var s = 0;
+    for (var i = 1; i <= 10; ++i) s = app.add(s, i);
+    app.log("sum(1..10) via C++ add() = " + s);
+
+    // 2) 操作属性（带 NOTIFY 信号）
+    app.counter = 100;
+    app.log("counter set to " + app.counter);
+
+    // 3) 用 Vector2 做点几何
+    var vs = [
+        new Vector2(1, 0),
+        new Vector2(0, 1),
+        new Vector2(3, 4),
+        new Vector2(-5, 12),
+    ];
+    vs.forEach(function (v) {
+        app.log(v.toString() + " length = " + v.length().toFixed(3));
+    });
+
+    // 4) 异常会被 C++ 端 checkError 捕获
+    try {
+        JSON.parse("not-json");
+    } catch (e) {
+        app.log("caught in JS: " + e.message);
+    }
+
+    // 5) 把对象 echo 一圈，验证 QVariant 互转
+    var echoed = app.echo({ list: [1, 2, 3], name: "demo" });
+    app.log("echoed.name = " + echoed.name + ", echoed.list.length = " + echoed.list.length);
+})();

--- a/examples/qt-jsengine-example/scripts/hello.js
+++ b/examples/qt-jsengine-example/scripts/hello.js
@@ -1,0 +1,14 @@
+// hello.js —— 由 QJSEngine 加载的最简单脚本
+
+function greet(name) {
+    return "Hello, " + name + "! (from hello.js)";
+}
+
+// 顶层语句也会被执行
+var pi = Math.PI;
+var msg = "hello.js loaded, PI = " + pi.toFixed(4);
+
+// QJSEngine 安装了 ConsoleExtension 之后可用 console.log
+if (typeof console !== "undefined") {
+    console.log(msg);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

新增 `examples/qt-jsengine-example/`，演示如何在 C++ 中通过 **Qt JavaScript 模块**（`QJSEngine`，`Qt Qml` 模块提供）嵌入 JavaScript 脚本，并在 C++ 与 JS 之间双向通信。

> 适用 Qt 5.12+ 与 Qt 6。

## 文件结构

```
examples/qt-jsengine-example/
├── CMakeLists.txt              # CMake 构建（推荐，Qt5/Qt6 自适配）
├── qt_jsengine_example.pro     # qmake 构建
├── main.cpp                    # 宿主程序，6 个演示
├── scripts/
│   ├── hello.js
│   └── app_logic.js
└── README.md
```

## 演示内容

| 编号 | 主题 | 关键 API |
| --- | --- | --- |
| 1 | 直接执行字符串脚本 | `QJSEngine::evaluate` |
| 2 | 加载 `.js` 文件并调用其中函数 | `QJSValue::call` |
| 3 | 把 `QObject` 暴露给 JS（属性 / 槽 / 信号） | `QJSEngine::newQObject` |
| 4 | 把 C++ 信号连到 JS 回调 | JS 端 `signal.connect(handler)` |
| 5 | 让 JS `new` C++ 类型 | `QJSEngine::newQMetaObject` |
| 6 | 综合脚本 (`scripts/app_logic.js`) | 上述能力组合 |

并提供：

- 统一的 JS 异常处理（含 `fileName / lineNumber / stack`）。
- `ConsoleExtension`，让脚本可用 `console.log/warn/error`。
- 关于对象所有权（`QQmlEngine::CppOwnership`）的注释。

## 构建

CMake（推荐）：

```bash
cd examples/qt-jsengine-example
cmake -S . -B build -DCMAKE_PREFIX_PATH=<Qt 安装前缀>
cmake --build build
./build/qt_jsengine_example
```

qmake：

```bash
qmake && make && ./qt_jsengine_example
```

## 备注

- 该改动只新增 `examples/` 子目录，不影响 Box2D 核心代码与现有构建系统。
- 由于 CI 环境没有安装 Qt，未在本仓库 CI 中加入构建步骤；可作为独立示例使用。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32bc6a22-0774-492f-b7d6-a04efe7a22fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32bc6a22-0774-492f-b7d6-a04efe7a22fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

